### PR TITLE
Create SimpleBackListener Behaviour

### DIFF
--- a/examples/collector/assets/Scenes/SettingsScene.php
+++ b/examples/collector/assets/Scenes/SettingsScene.php
@@ -2,7 +2,22 @@
 
 namespace Sendama\Examples\Collector\Scenes;
 
-class SettingsScene
-{
+use Sendama\Engine\Core\Behaviours\SimpleBackListener;
+use Sendama\Engine\Core\Behaviours\SimpleQuitListener;
+use Sendama\Engine\Core\GameObject;
+use Sendama\Engine\Core\Scenes\AbstractScene;
 
+class SettingsScene extends AbstractScene
+{
+  /**
+   * @inheritDoc
+   */
+  public function awake(): void
+  {
+    $levelManager = new GameObject('Level Manager');
+    $levelManager->addComponent(SimpleQuitListener::class);
+    $levelManager->addComponent(SimpleBackListener::class);
+
+    $this->add($levelManager);
+  }
 }

--- a/examples/collector/assets/Scenes/SettingsScene.php
+++ b/examples/collector/assets/Scenes/SettingsScene.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sendama\Examples\Collector\Scenes;
+
+class SettingsScene
+{
+
+}

--- a/examples/collector/collector.php
+++ b/examples/collector/collector.php
@@ -3,8 +3,10 @@
 use Amasiye\Figlet\FontName;
 use Sendama\Engine\Game;
 use Sendama\Engine\Core\Scenes\TitleScene;
+use Sendama\Engine\UI\Menus\MenuItem;
 use Sendama\Examples\Collector\Scenes\Level01;
 use Sendama\Examples\Collector\Scenes\Level02;
+use Sendama\Examples\Collector\Scenes\SettingsScene;
 
 require '../../vendor/autoload.php';
 
@@ -13,12 +15,23 @@ function bootstrap(): void
   $gameName = 'The Collector'; // This will be overwritten by the .env file
   $game = new Game($gameName);
 
+  $settingsScene = new SettingsScene('Settings');
   $titleScene = new TitleScene('Title Screen');
   $titleScene->setTitle($gameName);
-  $titleScene->setTitleFont(FontName::BASIC);
+  $titleScene
+    ->setTitleFont(FontName::BASIC)
+    ->addMenuItems(
+      new MenuItem(
+        'Settings',
+        'The main settings menu',
+        '⚙️',
+        fn() => loadScene('Settings')
+      )
+    );
 
   $game->addScenes(
     $titleScene,
+    $settingsScene,
     new Level01('Level01'),
     new Level02('Level02'),
   );

--- a/src/Core/Behaviours/SimpleBackListener.php
+++ b/src/Core/Behaviours/SimpleBackListener.php
@@ -3,6 +3,8 @@
 namespace Sendama\Engine\Core\Behaviours;
 
 use Sendama\Engine\Core\Behaviours\Behaviour;
+use Sendama\Engine\Debug\Debug;
+use Sendama\Engine\Exceptions\Scenes\SceneNotFoundException;
 use Sendama\Engine\IO\Enumerations\KeyCode;
 use Sendama\Engine\IO\Input;
 
@@ -18,12 +20,22 @@ class SimpleBackListener extends Behaviour
    *
    * @var array<KeyCode> $backKeys The keys that will go back.
    */
-  protected array $backKeys = [KeyCode::ESCAPE, KeyCode::BACKSPACE];
+  protected array $backKeys = [KeyCode::B, KeyCode::b, KeyCode::BACKSPACE];
 
+  protected int $nextPrintTime = 0;
+
+  /**
+   * @throws SceneNotFoundException
+   */
   public function onUpdate(): void
   {
+    if (time() > $this->nextPrintTime)
+    {
+      $this->nextPrintTime = time() + 1;
+    }
     if (Input::isAnyKeyPressed($this->backKeys))
     {
+      Debug::log('Going back');
       loadPreviousScene();
     }
   }

--- a/src/Core/Behaviours/SimpleBackListener.php
+++ b/src/Core/Behaviours/SimpleBackListener.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Sendama\Engine\Core\Behaviours;
+
+use Sendama\Engine\Core\Behaviours\Behaviour;
+use Sendama\Engine\IO\Enumerations\KeyCode;
+use Sendama\Engine\IO\Input;
+
+/**
+ * Class SimpleBackListener is responsible for going back when the back keys are pressed.
+ *
+ * @package Sendama\Engine\Core\Behaviours
+ */
+class SimpleBackListener extends Behaviour
+{
+  /**
+   * The keys that will go back.
+   *
+   * @var array<KeyCode> $backKeys The keys that will go back.
+   */
+  protected array $backKeys = [KeyCode::ESCAPE, KeyCode::BACKSPACE];
+
+  public function onUpdate(): void
+  {
+    if (Input::isAnyKeyPressed($this->backKeys))
+    {
+      loadPreviousScene();
+    }
+  }
+
+  /**
+   * Sets the keys that will go back.
+   *
+   * @param array<KeyCode> $backKeys The keys that will go back.
+   * @return void
+   */
+  public function setBackKeys(array $backKeys): void
+  {
+    $this->backKeys = $backKeys;
+  }
+}

--- a/src/Core/GameObject.php
+++ b/src/Core/GameObject.php
@@ -9,7 +9,6 @@ use Sendama\Engine\Core\Interfaces\ComponentInterface;
 use Sendama\Engine\Core\Interfaces\GameObjectInterface;
 use Sendama\Engine\Core\Rendering\Renderer;
 use Sendama\Engine\Core\Scenes\SceneManager;
-use Sendama\Engine\Debug\Debug;
 
 /**
  * Class GameObject. This class represents a game object in the engine.
@@ -269,10 +268,7 @@ class GameObject implements GameObjectInterface
     {
       foreach ($this->components as $component)
       {
-        if ($component->isActive() && $component->isEnabled())
-        {
-          $component->start();
-        }
+        $component->start();
       }
     }
   }
@@ -286,10 +282,7 @@ class GameObject implements GameObjectInterface
     {
       foreach ($this->components as $component)
       {
-        if ($component->isActive() && $component->isEnabled())
-        {
-          $component->stop();
-        }
+        $component->stop();
       }
     }
   }

--- a/src/Core/Scenes/Interfaces/SceneNodeInterface.php
+++ b/src/Core/Scenes/Interfaces/SceneNodeInterface.php
@@ -19,7 +19,7 @@ interface SceneNodeInterface
   /**
    * Returns the previous scene.
    *
-   * @return SceneInterface|null The previous scene.
+   * @return SceneNodeInterface|null The previous scene.
    */
-  public function getPreviousScene(): ?SceneInterface;
+  public function getPreviousNode(): ?SceneNodeInterface;
 }

--- a/src/Core/Scenes/SceneManager.php
+++ b/src/Core/Scenes/SceneManager.php
@@ -73,11 +73,11 @@ final class SceneManager implements SingletonInterface, CanStart, CanResume, Can
   /**
    * Returns the previous scene.
    *
-   * @return SceneInterface|null The previous scene.
+   * @return SceneNodeInterface|null The previous scene.
    */
-  public function getPreviousScene(): ?SceneInterface
+  public function getPreviousSceneNode(): ?SceneNodeInterface
   {
-    return $this->activeScene?->getPreviousScene();
+    return $this->activeScene?->getPreviousNode();
   }
 
   /**
@@ -124,7 +124,7 @@ final class SceneManager implements SingletonInterface, CanStart, CanResume, Can
      */
     foreach ($scenes as $i => $scene)
     {
-      if (is_int($index) && $i === (int)$index)
+      if (is_int($index) && $i === $index)
       {
         $sceneToBeLoaded = $scene;
         break;
@@ -145,7 +145,7 @@ final class SceneManager implements SingletonInterface, CanStart, CanResume, Can
     $this->stop();
     $this->activeScene = new SceneNode(
       $sceneToBeLoaded->loadSceneSettings($this->settings),
-      $this->activeScene?->getScene()
+      $this->activeScene
     );
 
     $this->eventManager->dispatchEvent(new SceneEvent(SceneEventType::LOAD_END));
@@ -164,9 +164,9 @@ final class SceneManager implements SingletonInterface, CanStart, CanResume, Can
   {
     Debug::info("Loading previous scene");
 
-    if ($this->getPreviousScene())
+    if ($this->getPreviousSceneNode())
     {
-      return $this->loadScene($this->getPreviousScene()->getName());
+      return $this->loadScene($this->getPreviousSceneNode()->getScene()->getName());
     }
 
     return $this;

--- a/src/Core/Scenes/SceneNode.php
+++ b/src/Core/Scenes/SceneNode.php
@@ -4,6 +4,7 @@ namespace Sendama\Engine\Core\Scenes;
 
 use Sendama\Engine\Core\Scenes\Interfaces\SceneInterface;
 use Sendama\Engine\Core\Scenes\Interfaces\SceneNodeInterface;
+use Sendama\Engine\Debug\Debug;
 
 /**
  * The class SceneNode.
@@ -12,9 +13,15 @@ use Sendama\Engine\Core\Scenes\Interfaces\SceneNodeInterface;
  */
 final class SceneNode implements Interfaces\SceneNodeInterface
 {
+  /**
+   * Constructs a SceneNode.
+   *
+   * @param SceneInterface $scene The scene.
+   * @param SceneNodeInterface|null $previousNode The previous node.
+   */
   public function __construct(
     protected SceneInterface $scene,
-    protected ?SceneInterface $previousScene = null
+    protected ?SceneNodeInterface $previousNode = null
   )
   {
   }
@@ -30,8 +37,8 @@ final class SceneNode implements Interfaces\SceneNodeInterface
   /**
    * @inheritDoc
    */
-  public function getPreviousScene(): ?SceneInterface
+  public function getPreviousNode(): ?SceneNodeInterface
   {
-    return $this->previousScene;
+    return $this->previousNode;
   }
 }

--- a/src/Core/Scenes/TitleScene.php
+++ b/src/Core/Scenes/TitleScene.php
@@ -57,7 +57,7 @@ class TitleScene extends AbstractScene
     );
     $this->titleText->setFontName(FontName::BIG->value);
     $this->titleText->setText($gameName);
-    $this->titleLeftMargin = ($this->sceneManager->getSettings('screen_width') / 2) - ($this->titleText->getWidth() / 2);
+    $this->titleLeftMargin = round(($this->sceneManager->getSettings('screen_width') / 2) - ($this->titleText->getWidth() / 2));
     $this->titleTopMargin = 4;
     $this->titleText->setPosition(new Vector2(round($this->titleLeftMargin), round($this->titleTopMargin)));
 

--- a/src/Util/Functions.php
+++ b/src/Util/Functions.php
@@ -60,6 +60,12 @@ function loadScene(string|int $index): void
   SceneManager::getInstance()->loadScene($index);
 }
 
+/**
+ * Loads the next scene.
+ *
+ * @return void
+ * @throws SceneNotFoundException If the previous scene is not found.
+ */
 function loadPreviousScene(): void
 {
   SceneManager::getInstance()->loadPreviousScene();


### PR DESCRIPTION
Created a simple behavior to handle navigating back to the previous scene.

- Fixed issue with `loadPreviousScene()` free function where GameObjects would remaind disabled afrer loading a previously unloaded scene